### PR TITLE
chore: fix rebuild trigger versions

### DIFF
--- a/renovate.Dockerfile
+++ b/renovate.Dockerfile
@@ -7,13 +7,13 @@
 FROM scratch
 
 # EOL 2021-12-06
-# renovate: datasource=docker depName=php versioning=docker
+# renovate: datasource=github-releases depName=containerbase/php-prebuild
 ENV PHP_VERSION=7.3.33
 
 # EOL 2022-11-28
-# renovate: datasource=docker depName=php versioning=docker
+# renovate: datasource=github-releases depName=containerbase/php-prebuild
 ENV PHP_VERSION=7.4.28
 
 # EOL 2023-11-26
-# renovate: datasource=docker depName=php versioning=docker
+# renovate: datasource=github-releases depName=containerbase/php-prebuild
 ENV PHP_VERSION=8.0.16


### PR DESCRIPTION
We used the wrong datasource before